### PR TITLE
Weekend maintenance

### DIFF
--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -1,0 +1,34 @@
+import pytest
+
+from app import app
+
+
+class ConfigException(Exception):
+    pass
+
+
+@pytest.fixture
+def client():
+    client = app.test_client()
+    app.config['TESTING'] = True
+
+    yield client
+
+
+def test_debug_mode(client):
+    with open("config.py") as f:
+        if "DEBUG = False" not in f.read():
+            raise ConfigException("Build should not be in DEBUG mode.")
+
+
+def test_main_page(client):
+    rv = client.get('/')
+    assert b'LOGGED OUT' in rv.data
+
+
+def test_user_page(client):
+    with client.session_transaction() as sess:
+        sess['json_info'] = {'id': "1115081075", 'refresh_token': "AQDMxiy5GuPy55xDpV60tzUpUu06GZKGLRZMKu8gIdORUoSPFPQJ1N-qwudJC_yoIeX_xLbK8iNb7rE3vy9T1DmFiAoaV_-5qLx5hzA1BmcJ0RNAW4WhgC-ROZs4CIe_15vWUA"}
+    rv = client.get('/')
+
+    assert b'LOGGED OUT' not in rv.data

--- a/app/views.py
+++ b/app/views.py
@@ -61,7 +61,7 @@ def index_js():
 
 @app.route("/login")
 def login():
-    return spotifysso.authorize(callback='http://localhost:5000/callback')
+    return spotifysso.authorize(callback="http://localhost:5000/callback")
 
     # return spotifysso.authorize(callback=url_for('authorized', _external=True, _scheme="https"))
 

--- a/run.py
+++ b/run.py
@@ -1,3 +1,4 @@
 #!flask/bin/python
 from app import app
-app.run(debug=True, host='127.0.0.1', port=5000, threaded=True)
+
+app.run(host='0.0.0.0', port=5000, threaded=True)


### PR DESCRIPTION
# Description
Fix the backend by adding error handling and add some extra functionality during the weekend

### Error handling
- [ ] Rewrite the Spotify API calls with a queue, to handle timeouts.
- [ ] Push error that occur during the session to the user with *flash*
- [ ] Add error handling to the `API/spotify.py`
- [ ] Add error handling to `views.py`
- [ ] Add error handling to `query.py`

### Extra functionality
- [ ] Restructure functions so their location makes sense.
- [ ] Add more variables to `config.py` to make testing on localhost easier.
- [ ] Add song suggestions to the API
- [ ] Add the option to use `me` instead of there `userid` when the user is logged in.